### PR TITLE
feat: use the `ignore` crate to crawl the filesystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.2.2", features = ["derive"] }
+clap = { version = "4.3.0", features = ["derive"] }
 color-eyre = "0.6.2"
-console = "0.15.5"
+console = "0.15.7"
 crossbeam = "0.8.2"
 dirs = "5.0"
-git2 = "0.17.0"
+git2 = "0.17.1"
 indicatif = "0.17.3"
-num_cpus = "1.15.0"
 label-logger = { version = "0.2.0", features = ["indicatif"] }
+ignore = "0.4.20"

--- a/src/crawl.rs
+++ b/src/crawl.rs
@@ -1,97 +1,53 @@
 //! All the logic to crawl through directories in order to find git repos
 
 use crate::config::Arguments;
-use crossbeam::{queue::SegQueue, thread};
+use crossbeam::queue::SegQueue;
 use git2::Repository;
-use indicatif::ProgressBar;
-use label_logger::{format_label, indicatif::label_theme, OutputLabel};
-use std::{
-	cmp::max,
-	fs::read_dir,
-	io,
-	path::{Path, PathBuf},
-};
+use ignore::{WalkBuilder, WalkState};
+use label_logger::error;
+use std::path::Path;
 
 /// Spawn the threads needed for crawling directories
 #[allow(clippy::module_name_repetitions)]
 pub fn crawl_directory_for_repos(
 	directory: &Path,
 	settings: &Arguments,
-) -> io::Result<Vec<Repository>> {
-	// Contains paths to explore
-	let paths = SegQueue::new();
-	paths.push(directory.to_path_buf());
-
+) -> std::vec::Vec<git2::Repository> {
 	// Contains found repositories
 	let repositories = SegQueue::new();
 
-	// Set the number of threads to use for crawling
-	let thread_count = max(8, num_cpus::get() * 2);
+	let walker = WalkBuilder::new(directory)
+		.follow_links(settings.follow_symlinks)
+		.build_parallel();
 
-	let dirty_bar = ProgressBar::new(1).with_style(label_theme(OutputLabel::Info("Crawling")));
+	walker.run(|| {
+		let repositories = &repositories;
+		Box::new(move |result| {
+			match result {
+				Ok(entry) => {
+					if entry.file_type().map_or(false, |ft| ft.is_dir()) {
+						// Return is the directory is a repo
+						if let Ok(repo) = Repository::open(entry.path()) {
+							// Skip bare repos
+							if !repo.is_bare() {
+								repositories.push(repo);
 
-	thread::scope(|scope| {
-		for _ in 0..thread_count {
-			scope.spawn(|_| {
-				while let Some(path) = paths.pop() {
-					if let Err(error) = crawl(&path, &paths, &repositories, &dirty_bar, settings) {
-						let msg = format_label!(label: OutputLabel::Error("Error"), "could not crawl {}: {}", path.display(), error);
-						dirty_bar.println(msg);
-					};
+								return WalkState::Skip;
+							}
+						}
+					}
 				}
-			});
-		}
-	})
-	.map_err(|err| io::Error::new(
-		io::ErrorKind::Other,
-		format!("could not spawn threads because of error of type: {:?}", err.type_id())
-	))?;
-
-	dirty_bar.finish_and_clear();
-
-	Ok(repositories.into_iter().collect::<Vec<_>>())
-}
-
-// TODO: make tests for this function
-/// Search for git repositories and report folder to the given queue
-fn crawl(
-	directory: &PathBuf,
-	path_queue: &SegQueue<PathBuf>,
-	repositories: &SegQueue<Repository>,
-	dirty_bar: &ProgressBar,
-	settings: &Arguments,
-) -> io::Result<()> {
-	if directory.is_dir() {
-		if settings.show_directories {
-			dirty_bar.set_message(directory.display().to_string());
-		}
-
-		dirty_bar.inc(1);
-
-		// Return is the directory is a repo
-		if let Ok(repo) = Repository::open(directory) {
-			// Skip bare repos
-			if !repo.is_bare() {
-				repositories.push(repo);
-
-				return Ok(());
-			}
-		}
-
-		// Loop through the directory contents and add new directories to the queue
-		for entry in read_dir(directory)? {
-			let path = entry.map(|entry| entry.path())?;
-
-			if path.is_symlink() && !settings.follow_symlinks {
-				continue;
+				Err(ignore::Error::Io(error)) => {
+					error!("could not access path: {}", error);
+				}
+				Err(error) => {
+					error!("something wrong happened: {}", error);
+				}
 			}
 
-			if path.is_dir() {
-				path_queue.push(path);
-				dirty_bar.inc_length(1);
-			}
-		}
-	}
+			WalkState::Continue
+		})
+	});
 
-	Ok(())
+	repositories.into_iter().collect::<Vec<_>>()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ use crate::{
 };
 use clap::Parser;
 use color_eyre::eyre::{Context, ContextCompat};
-use console::Term;
 use dirs::home_dir;
 use label_logger::{console::style, error, info, log, success, warn, OutputLabel};
 use std::{path::Path, time::Instant};
@@ -68,12 +67,7 @@ fn main() -> color_eyre::Result<()> {
 	let begin_search_time = Instant::now();
 
 	// Find git repositories in the specified directory
-	let repos = crawl_directory_for_repos(&search_directory, &args)
-		.wrap_err("Something went wrong while trying to crawl the directory")?;
-
-	if Term::stdout().is_term() {
-		Term::stdout().clear_line().ok();
-	}
+	let repos = crawl_directory_for_repos(&search_directory, &args);
 
 	// Exit if no git repositories were found
 	if repos.is_empty() {


### PR DESCRIPTION
<details>
<summary>Benchmarks results:</summary>

```bash
$ hyperfine -w 3 './git-leave-atomics ~' './git-leave-ignore ~' './git-leave-v1.5.5 ~' './git-leave-v1.6.0 ~'
Benchmark 1: ./git-leave-atomics ~
  Time (mean ± σ):      8.080 s ±  0.365 s    [User: 11.586 s, System: 41.061 s]
  Range (min … max):    7.372 s …  8.426 s    10 runs
 
Benchmark 2: ./git-leave-ignore ~
  Time (mean ± σ):      9.424 s ±  0.225 s    [User: 7.180 s, System: 8.101 s]
  Range (min … max):    9.285 s … 10.060 s    10 runs
 
Benchmark 3: ./git-leave-v1.5.5 ~
  Time (mean ± σ):      7.045 s ±  0.276 s    [User: 11.612 s, System: 42.350 s]
  Range (min … max):    6.852 s …  7.604 s    10 runs
 
Benchmark 4: ./git-leave-v1.6.0 ~
  Time (mean ± σ):      6.923 s ±  0.198 s    [User: 11.983 s, System: 43.332 s]
  Range (min … max):    6.714 s …  7.273 s    10 runs
 
Summary
  './git-leave-v1.6.0 ~' ran
    1.02 ± 0.05 times faster than './git-leave-v1.5.5 ~'
    1.17 ± 0.06 times faster than './git-leave-atomics ~'
    1.36 ± 0.05 times faster than './git-leave-ignore ~'
```

```bash
$ hyperfine -w 3 './git-leave-atomics /' './git-leave-ignore /' './git-leave-v1.5.5 /' './git-leave-v1.6.0 /'
Benchmark 1: ./git-leave-atomics /
  Time (mean ± σ):     51.882 s ± 32.760 s    [User: 59.956 s, System: 415.606 s]
  Range (min … max):   35.203 s … 142.587 s    10 runs
 
Benchmark 2: ./git-leave-ignore /
  Time (mean ± σ):     78.562 s ±  2.335 s    [User: 53.332 s, System: 97.166 s]
  Range (min … max):   75.471 s … 81.365 s    10 runs
 
Benchmark 3: ./git-leave-v1.5.5 /
  Time (mean ± σ):     42.692 s ±  4.420 s    [User: 60.576 s, System: 400.734 s]
  Range (min … max):   36.086 s … 49.337 s    10 runs
 
Benchmark 4: ./git-leave-v1.6.0 /
  Time (mean ± σ):     41.119 s ±  0.822 s    [User: 60.986 s, System: 412.161 s]
  Range (min … max):   39.604 s … 42.113 s    10 runs
 
Summary
  './git-leave-v1.6.0 /' ran
    1.04 ± 0.11 times faster than './git-leave-v1.5.5 /'
    1.26 ± 0.80 times faster than './git-leave-atomics /'
    1.91 ± 0.07 times faster than './git-leave-ignore /'
```

</details>